### PR TITLE
Implement an example to convert output from json to csv table

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,22 @@ You have an example here: [resources/checkconsents_config.yml] (resources/checkc
 
 These predictions were obtained using default CheckConsents parameters for conversion of pdf into png with a **density of 300 dpi**, and **no colorscale transformation**.
 
-
 > [!note]
 > Modification of curent values of CheckConsents parameters may decrease file size of png and therefore increase execution time but may also impact accuracy of the detection. 
 
+## Parsing the output of CheckConsents tool
 
+The json output from checkconsents could be parsed to generate other formats or combined with other informations.
 
+There is an example of parser which generate a csv file from the `consents.json` file.
 
-## Development 
+It creates a table with the following header:
+
+```Text
+"Input directory","Input filename","Result of the automatic detection","Debug image filename","Output directory"
+```
+
+## Development
 
 You can use virtualenv locally or use the docker compose file: `compose-dev.yml`.
 We recommend to use docker which makes easier the management of environment.

--- a/scripts/consents_json2csv.py
+++ b/scripts/consents_json2csv.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import argparse
+import csv
+import json
+import os
+
+parser = argparse.ArgumentParser(prog='consents_json2csv.py', description='Convert checkconsents output to csv format')
+parser.add_argument('json_filepath')
+args = parser.parse_args()
+
+#output_filepath = os.path.join(os.path.dirname(args.json_filepath), os.path.basename(args.json_filepath))
+output_filepath = os.path.splitext(args.json_filepath)[0] + '.csv'
+
+#with open('target/CheckConsents_20240918-163024/consents.json', 'r') as f:
+with open(args.json_filepath, 'r') as f:
+    data = json.load(f)
+
+#with open('target/CheckConsents_20240918-163024/consents.csv', 'w', newline='') as csvfile:
+with open(output_filepath, 'w', newline='') as csvfile:
+    #writer = csv.writer(csvfile, delimiter=';', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    writer = csv.writer(csvfile, quotechar='"', quoting=csv.QUOTE_STRINGS)
+    writer.writerow(['Input directory', 
+                     'Input filename', 
+                     'Result of the automatic detection', 
+                     'Debug image filename', 
+                     'Output directory'])
+    for d in data:
+        img_basename = None
+        img_dirname = None
+        if d['debug_img_filepath']:
+            img_basename = os.path.basename(d['debug_img_filepath'])
+            img_dirname = os.path.dirname(d['debug_img_filepath'])
+        row = (os.path.dirname(d['pdf_filepath']), 
+               os.path.basename(d['pdf_filepath']), 
+               d['consent'], 
+               img_basename, 
+               img_dirname)
+        writer.writerow(row)
+       # writer.writerow([os.path.dirname(d['pdf_filepath']), os.path.basename(d['pdf_filepath']), d['consent'], os.path.basename(d['debug_img_filepath']), os.path.dirname(d['debug_img_filepath'])])


### PR DESCRIPTION
The json output from checkconsents could be parsed to generate other formats or combined with other informations.

There is an example of script to generate a csv file from the `consents.json` file: `scripts/constents_json2csv.py`

It creates a table with the following header:

```
"Input directory","Input filename","Result of the automatic detection","Debug image filename","Output directory"
```