### PR TITLE
Fix find best template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ARG DOCKER_REQUIREMENTS=requirements.txt
 ####### METADATA #######
 LABEL authors="Adrien Josso Rigonato <adrien.josso-rigonato@genomecad.fr>, David Salgado <david.salgado@inserm.fr>"
 LABEL base.image="python:3.12-slim"
-LABEL version="1.2.0"
+LABEL version="1.3.0"
 LABEL software="checkconsents"
-LABEL software.version="1.2.0"
+LABEL software.version="1.3.0"
 LABEL license="AGLP 3"
 LABEL about.tags="OMR"
 

--- a/consentforms/checkconsents.py
+++ b/consentforms/checkconsents.py
@@ -3,7 +3,7 @@
 __authors__ = ("David Salgado", "Adrien Josso Rigonato")
 __contact__ = ("david.salgado@inserm.fr", "adrien.josso-rigonato@genomecad.fr")
 __copyright__ = "GNU AGLP3"
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __prog_name__ = "CheckConsents"
 
 import argparse

--- a/consentforms/checkconsents.py
+++ b/consentforms/checkconsents.py
@@ -335,6 +335,10 @@ def main(cli_args):
                         logger.error(te)
                         errors_img_analysis.append(te)
                         continue
+                    except templates.FindTemplateError as fte:
+                        logger.error(te)
+                        errors_img_analysis.append(te)
+                        continue
                     logger.debug(popen(f"ls -la {tmpdirname}").read())
                     if svg_template_filepath is None:
                         logger.debug(f"{img_path} - no template")

--- a/consentforms/checkconsents.py
+++ b/consentforms/checkconsents.py
@@ -332,8 +332,9 @@ def main(cli_args):
                                                             config.templates,
                                                             config.parsing_header_limit)
                     except TesseractError as te:
-                        logger.error(te)
-                        errors_img_analysis.append(te)
+                        msg = f"({img}) " + te
+                        logger.error(msg)
+                        errors_img_analysis.append(msg)
                         continue
                     except templates.FindTemplateError as fte:
                         logger.error(te)

--- a/consentforms/images/__init__.py
+++ b/consentforms/images/__init__.py
@@ -3,7 +3,7 @@
 """
 
 __authors__ = ("David Salgado", "Adrien Josso Rigonato")
-__contact__ = ("david.salgado@genomecad.fr", "adrien.josso-rigonato@genomecad.fr")
+__contact__ = ("david.salgado@inserm.fr", "adrien.josso-rigonato@genomecad.fr")
 __copyright__ = "GNU AGLP3"
 __version__ = "1.2.0"
 

--- a/consentforms/templates/__init__.py
+++ b/consentforms/templates/__init__.py
@@ -3,9 +3,9 @@ Detect template of image
 """
 
 __authors__ = ("David Salgado", "Adrien Josso Rigonato")
-__contact__ = ("david.salgado@genomecad.fr", "adrien.josso-rigonato@genomecad.fr")
+__contact__ = ("david.salgado@inserm.fr", "adrien.josso-rigonato@genomecad.fr")
 __copyright__ = "GNU AGLP3"
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 import logging


### PR DESCRIPTION
🔨 FIX #10 

Implement a fix to solve the bug described into #10:

- [ ] check if any line is returned by OCR
- [ ] use the min value between number of lines and the limit from configuration
- [ ] raise a new Exception type `FindTemplateError`
- [ ] catch the exception at main level to log it and move to next image whitout stopping the current process

Other:
- Update contact informations
- Upgrade versions
